### PR TITLE
Add descriptive alt text to images

### DIFF
--- a/bar/bar.html
+++ b/bar/bar.html
@@ -15,47 +15,47 @@
         <h4>Select Demo:</h4>
         <div class="main_demo">
             <div class="d_col">
-                <a href="index-new-demo-1.html"><img src="images/new_preview1.jpg" alt="" /></a>
+                <a href="index-new-demo-1.html"><img src="images/new_preview1.jpg" alt="Preview image for Default demo" /></a>
                 <h6>Default</h6>
             </div>
             <div class="d_col">
-                <a href="index-new-demo-2.html"><img src="images/new_preview2.jpg" alt="" /></a>
+                <a href="index-new-demo-2.html"><img src="images/new_preview2.jpg" alt="Preview image for Dark demo" /></a>
                 <h6>Dark</h6>
             </div>
             <div class="clear"></div>
             <div class="d_col">
-                <a href="index-new-demo-3.html"><img src="images/new_preview3.jpg" alt="" /></a>
+                <a href="index-new-demo-3.html"><img src="images/new_preview3.jpg" alt="Preview image for Developer demo" /></a>
                 <h6>Developer</h6>
             </div>
             <div class="d_col">
-                <a href="index-new-demo-4.html"><img src="images/new_preview4.jpg" alt="" /></a>
+                <a href="index-new-demo-4.html"><img src="images/new_preview4.jpg" alt="Preview image for Designer demo" /></a>
                 <h6>Designer</h6>
             </div>
             <div class="clear"></div>
             <div class="d_col">
-                <a href="index-new-demo-5.html"><img src="images/new_preview5.jpg" alt="" /></a>
+                <a href="index-new-demo-5.html"><img src="images/new_preview5.jpg" alt="Preview image for Trainer demo" /></a>
                 <h6>Trainer</h6>
             </div>
             <div class="d_col">
-                <a href="index-new-demo-6.html"><img src="images/new_preview6.jpg" alt="" /></a>
+                <a href="index-new-demo-6.html"><img src="images/new_preview6.jpg" alt="Preview image for Musician demo" /></a>
                 <h6>Musician</h6>
             </div>
             <div class="clear"></div>
             <div class="d_col">
-                <a href="index-new-demo-7.html"><img src="images/new_preview7.jpg" alt="" /></a>
+                <a href="index-new-demo-7.html"><img src="images/new_preview7.jpg" alt="Preview image for Writer demo" /></a>
                 <h6>Writer</h6>
             </div>
             <div class="d_col">
-                <a href="index-new-demo-8.html"><img src="images/new_preview8.jpg" alt="" /></a>
+                <a href="index-new-demo-8.html"><img src="images/new_preview8.jpg" alt="Preview image for Lawyer demo" /></a>
                 <h6>Lawyer</h6>
             </div>
             <div class="clear"></div>
             <div class="d_col">
-                <a href="index-classic.html"><img src="images/new_preview9.png" alt="" /></a>
+                <a href="index-classic.html"><img src="images/new_preview9.png" alt="Preview image for Classic demo" /></a>
                 <h6>Classic</h6>
             </div>
             <div class="d_col">
-                <a href="index-classic-dark.html"><img src="images/new_preview10.png" alt="" /></a>
+                <a href="index-classic-dark.html"><img src="images/new_preview10.png" alt="Preview image for Classic Dark demo" /></a>
                 <h6>Classic Dark</h6>
             </div>
             <div class="clear"></div>

--- a/index.html
+++ b/index.html
@@ -656,7 +656,7 @@
                                                             <div class="image">
                                                                 <a href="images/recommand/rec1.png" class="has-popup-image">
 
-                                                                    <img src="images/recommand/rec1.png" alt="" class="responsive" />
+                                                                    <img src="images/recommand/rec1.png" alt="LinkedIn recommendation screenshot 1" class="responsive" />
 
                                                                     <span class="info">
 
@@ -694,7 +694,7 @@
                                                             <div class="image">
                                                                 <a href="images/recommand/rec2.png" class="has-popup-image">
 
-                                                                    <img src="images/recommand/rec2.png" alt="" class="responsive" />
+                                                                    <img src="images/recommand/rec2.png" alt="LinkedIn recommendation screenshot 2" class="responsive" />
 
                                                                     <span class="info">
 
@@ -732,7 +732,7 @@
                                                             <div class="image">
                                                                 <a href="images/recommand/rec3.png" class="has-popup-image">
 
-                                                                    <img src="images/recommand/rec3.png" alt="" class="responsive" />
+                                                                    <img src="images/recommand/rec3.png" alt="LinkedIn recommendation screenshot 3" class="responsive" />
 
                                                                     <span class="info">
 
@@ -771,7 +771,7 @@
                                                             <div class="image">
                                                                 <a href="images/recommand/rec4.png" class="has-popup-image">
 
-                                                                    <img src="images/recommand/rec4.png" alt="" class="responsive" />
+                                                                    <img src="images/recommand/rec4.png" alt="LinkedIn recommendation screenshot 4" class="responsive" />
 
                                                                     <span class="info">
 
@@ -810,7 +810,7 @@
                                                             <div class="image">
                                                                 <a href="images/recommand/rec5.png" class="has-popup-image">
 
-                                                                    <img src="images/recommand/rec5.png" alt="" class="responsive" />
+                                                                    <img src="images/recommand/rec5.png" alt="LinkedIn recommendation screenshot 5" class="responsive" />
 
                                                                     <span class="info">
 
@@ -849,7 +849,7 @@
                                                             <div class="image">
                                                                 <a href="images/recommand/rec6.png" class="has-popup-image">
 
-                                                                    <img src="images/recommand/rec6.png" alt="" class="responsive" />
+                                                                    <img src="images/recommand/rec6.png" alt="LinkedIn recommendation screenshot 6" class="responsive" />
 
                                                                     <span class="info">
 
@@ -929,7 +929,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="images/works/work1.jpg" class="has-popup-image">
-											<img src="images/works/work1.jpg" alt="" />
+                                                                                        <img src="images/works/work1.jpg" alt="Motorcycle Helmet project image" />
 											<span class="info">
 												<span class="ion ion-image"></span>
 											</span>
@@ -948,7 +948,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="#popup-1" class="has-popup-media">
-                                            <img src="images/works/DCS_Positive Impact.jpg" alt="" />
+                                            <img src="images/works/DCS_Positive Impact.jpg" alt="Digitization of Credit and Client Service project screenshot" />
                                             <span class="info">
                                                 <span class="ion ion-images"></span>
                                             </span>
@@ -961,7 +961,7 @@
                                     <div id="popup-1" class="popup-box mfp-fade mfp-hide">
                                         <div class="content">
                                             <div class="image">
-                                                <img src="images/works/DCS_Positive Impact.jpg" alt="">
+                                                <img src="images/works/DCS_Positive Impact.jpg" alt="Detailed view of Digitization of Credit and Client Service project" />
                                             </div>
                                             <div class="desc">
                                                 <div class="post-box">
@@ -1044,7 +1044,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="https://vimeo.com/97102654" class="has-popup-video">
-											<img src="images/works/work2.jpg" alt="" />
+                                                                                        <img src="images/works/work2.jpg" alt="Video thumbnail for Minimalism Shapes project" />
 											<span class="info">
 												<span class="ion ion-videocamera"></span>
 											</span>
@@ -1062,7 +1062,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="https://w.soundcloud.com/player/?visual=true&url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F221650664&show_artwork=true" class="has-popup-music">
-											<img src="images/works/work3.jpg" alt="" />
+                                                                                        <img src="images/works/work3.jpg" alt="Cover art for Staircase music project" />
 											<span class="info">
 												<span class="ion ion-music-note"></span>
 											</span>
@@ -1080,7 +1080,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="#popup-1" class="has-popup-media">
-											<img src="images/works/work4.jpg" alt="" />
+                                                                                        <img src="images/works/work4.jpg" alt="Mobile Application design preview" />
 											<span class="info">
 												<span class="ion ion-images"></span>
 											</span>
@@ -1093,7 +1093,7 @@
                                     <div id="popup-1" class="popup-box mfp-fade mfp-hide">
                                         <div class="content">
                                             <div class="image">
-                                                <img src="images/works/work4.jpg" alt="">
+                                                <img src="images/works/work4.jpg" alt="Detailed view of Mobile Application design" />
                                             </div>
                                             <div class="desc">
                                                 <div class="post-box">
@@ -1137,7 +1137,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="#gallery-1" class="has-popup-gallery">
-											<img src="images/works/work5.jpg" alt="" />
+                                                                                        <img src="images/works/work5.jpg" alt="Gallery image for Gereal Travels project" />
 											<span class="info">
 												<span class="ion ion-images"></span>
 											</span>
@@ -1160,7 +1160,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="https://w.soundcloud.com/player/?visual=true&url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F221650664&show_artwork=true" class="has-popup-music">
-											<img src="images/works/work8.jpg" alt="" />
+                                                                                        <img src="images/works/work8.jpg" alt="Cover art for Daylight Entrance music project" />
 											<span class="info">
 												<span class="ion ion-music-note"></span>
 											</span>
@@ -1178,7 +1178,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="https://vimeo.com/97102654" class="has-popup-video">
-											<img src="images/works/work6.jpg" alt="" />
+                                                                                        <img src="images/works/work6.jpg" alt="Video thumbnail for Architecture project" />
 											<span class="info">
 												<span class="ion ion-videocamera"></span>
 											</span>
@@ -1196,7 +1196,7 @@
                                 <div class="box-item">
                                     <div class="image">
                                         <a href="#popup-2" class="has-popup-media">
-											<img src="images/works/work7.jpg" alt="" />
+                                                                                        <img src="images/works/work7.jpg" alt="Social Website design preview" />
 											<span class="info">
 												<span class="ion ion-images"></span>
 											</span>
@@ -1209,7 +1209,7 @@
                                     <div id="popup-2" class="popup-box mfp-fade mfp-hide">
                                         <div class="content">
                                             <div class="image">
-                                                <img src="images/works/work7.jpg" alt="">
+                                                <img src="images/works/work7.jpg" alt="Detailed view of Social Website design" />
                                             </div>
                                             <div class="desc">
                                                 <div class="post-box">


### PR DESCRIPTION
## Summary
- provide meaningful alt text for recommendation and portfolio images on index page
- describe demo preview thumbnails in bar/bar.html for better accessibility

## Testing
- `python - <<'PY' ...` (index.html alt check)
- `python - <<'PY' ...` (bar.html alt check)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c7df556c832b8ff9e3768796e14c